### PR TITLE
test-script.nix: fix argument indexing bug

### DIFF
--- a/test-script.nix
+++ b/test-script.nix
@@ -195,7 +195,6 @@ in shellcheckedScript "run-tests.sh"
 
   destdir=$(realpath "$1")
   mkdir -p "$destdir"
-  shift
 
   set +eu
 


### PR DESCRIPTION
Currently the second argument to the script is completely ignored; shift
is called, but then $1 is never used afterwards.